### PR TITLE
feat: Fix new lines and quotes

### DIFF
--- a/packages/trpc-panel/src/react-app/components/form/ProcedureForm/DescriptionSection.tsx
+++ b/packages/trpc-panel/src/react-app/components/form/ProcedureForm/DescriptionSection.tsx
@@ -38,7 +38,12 @@ export function DocumentationSection({
                         {`${key}: `}
                       </td>
                       <td className="pl-4 text-sm text-gray-500 py-2">
-                        {`${value}`}
+                        {value.split("\n").map((line, index) => (
+                          <React.Fragment key={index}>
+                            {line}
+                            <br />
+                          </React.Fragment>
+                        ))}
                       </td>
                     </tr>
                   )

--- a/packages/trpc-panel/src/react-app/components/form/ProcedureForm/Response.tsx
+++ b/packages/trpc-panel/src/react-app/components/form/ProcedureForm/Response.tsx
@@ -31,6 +31,11 @@ export function Response({
           maxDisplayLength={100}
           groupArraysAfterLength={500}
           indentWidth={2}
+          onCopy={async (_, value) => {
+            await navigator.clipboard.writeText(
+              JSON.stringify(value, null, 2).slice(1, -1)
+            );
+          }}
         />
       </FormSection>
     );


### PR DESCRIPTION
This should fix the two issues we have had with trpc-panel rendering.

<details><summary>Details</summary>
<p>

![image](https://github.com/clburlison/trpc-panel/assets/5123982/1af8e66a-7ada-412a-aed6-98d59223150f)
</p>
</details> 

Confirmed quotes are stripped as well. 